### PR TITLE
MC-30896: Move PayPalRecaptcha module to Magento Security Extensions

### DIFF
--- a/ReCaptchaAdminUi/etc/di.xml
+++ b/ReCaptchaAdminUi/etc/di.xml
@@ -7,7 +7,7 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <virtualType name="Magento\ReCaptchaApi\Model\OptionSource\Type"
+    <virtualType name="Magento\ReCaptchaAdminUi\Model\OptionSource\Type"
                  type="Magento\ReCaptchaAdminUi\Model\OptionSource">
         <arguments>
             <argument name="options" xsi:type="array">

--- a/ReCaptchaCheckout/view/frontend/layout/checkout_index_index.xml
+++ b/ReCaptchaCheckout/view/frontend/layout/checkout_index_index.xml
@@ -28,7 +28,6 @@
                                                                     <item name="displayArea" xsi:type="string">additional-login-form-fields</item>
                                                                     <item name="configSource" xsi:type="string">checkoutConfig</item>
                                                                     <item name="reCaptchaId" xsi:type="string">recaptcha-checkout-inline-login</item>
-                                                                    <item name="zone" xsi:type="string">login</item>
                                                                 </item>
                                                             </item>
                                                         </item>
@@ -47,7 +46,6 @@
                                                                     <item name="displayArea" xsi:type="string">additional-login-form-fields</item>
                                                                     <item name="configSource" xsi:type="string">checkoutConfig</item>
                                                                     <item name="reCaptchaId" xsi:type="string">recaptcha-checkout-inline-login-billing</item>
-                                                                    <item name="zone" xsi:type="string">login</item>
                                                                 </item>
                                                             </item>
                                                         </item>

--- a/ReCaptchaContact/etc/adminhtml/system.xml
+++ b/ReCaptchaContact/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
                 <field id="contact" translate="label" type="select" sortOrder="140" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Contact Us</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaCustomer/etc/adminhtml/system.xml
+++ b/ReCaptchaCustomer/etc/adminhtml/system.xml
@@ -13,17 +13,17 @@
                 <field id="customer_login" translate="label" type="select" sortOrder="110" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Customer Login</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
                 <field id="customer_forgot_password" translate="label" type="select" sortOrder="120" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Forgot Password</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
                 <field id="customer_create" translate="label" type="select" sortOrder="130" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Create New Customer Account</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -89,8 +89,7 @@ define(
                     $parentForm,
                     $wrapper,
                     $reCaptcha,
-                    widgetId,
-                    listeners;
+                    widgetId;
 
                 if (this.captchaInitialized) {
                     return;
@@ -129,9 +128,26 @@ define(
 
                 // eslint-disable-next-line no-undef
                 widgetId = grecaptcha.render(this.getReCaptchaId(), parameters);
+                this.initParentForm($parentForm, widgetId);
 
-                if (this.getIsInvisibleRecaptcha() && $parentForm.length > 0) {
-                    $parentForm.submit(function (event) {
+                registry.ids.push(this.getReCaptchaId());
+                registry.captchaList.push(widgetId);
+                registry.tokenFields.push(this.tokenField);
+
+            },
+
+            /**
+             * Initialize parent form.
+             *
+             * @param {Object} parentForm
+             * @param {String} widgetId
+             */
+            initParentForm: function (parentForm, widgetId) {
+                var me = this,
+                    listeners;
+
+                if (this.getIsInvisibleRecaptcha() && parentForm.length > 0) {
+                    parentForm.submit(function (event) {
                         if (!me.tokenField.value) {
                             // eslint-disable-next-line no-undef
                             grecaptcha.execute(widgetId);
@@ -141,21 +157,16 @@ define(
                     });
 
                     // Move our (last) handler topmost. We need this to avoid submit bindings with ko.
-                    listeners = $._data($parentForm[0], 'events').submit;
+                    listeners = $._data(parentForm[0], 'events').submit;
                     listeners.unshift(listeners.pop());
 
                     // Create a virtual token field
                     this.tokenField = $('<input type="text" name="token" style="display: none" />')[0];
-                    this.$parentForm = $parentForm;
-                    $parentForm.append(this.tokenField);
+                    this.$parentForm = parentForm;
+                    parentForm.append(this.tokenField);
                 } else {
                     this.tokenField = null;
                 }
-
-                registry.ids.push(this.getReCaptchaId());
-                registry.captchaList.push(widgetId);
-                registry.tokenFields.push(this.tokenField);
-
             },
 
             validateReCaptcha: function (state) {

--- a/ReCaptchaNewsletter/etc/adminhtml/system.xml
+++ b/ReCaptchaNewsletter/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable Invisible reCAPTCHA in Newsletter Subscription</label>
                     <comment>If enabled, a badge will be displayed in every page.</comment>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaPaypal/Block/LayoutProcessor/Checkout/Onepage.php
+++ b/ReCaptchaPaypal/Block/LayoutProcessor/Checkout/Onepage.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ReCaptchaPaypal\Block\LayoutProcessor\Checkout;
+
+use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
+use Magento\ReCaptchaUi\Model\IsCaptchaEnabledInterface;
+use Magento\ReCaptchaUi\Model\UiConfigResolverInterface;
+
+/**
+ * Provides reCaptcha component configuration.
+ */
+class Onepage implements LayoutProcessorInterface
+{
+    /**
+     * @var UiConfigResolverInterface
+     */
+    private $captchaUiConfigResolver;
+
+    /**
+     * @var IsCaptchaEnabledInterface
+     */
+    private $isCaptchaEnabled;
+
+    /**
+     * @param UiConfigResolverInterface $captchaUiConfigResolver
+     * @param IsCaptchaEnabledInterface $isCaptchaEnabled
+     */
+    public function __construct(
+        UiConfigResolverInterface $captchaUiConfigResolver,
+        IsCaptchaEnabledInterface $isCaptchaEnabled
+    ) {
+        $this->captchaUiConfigResolver = $captchaUiConfigResolver;
+        $this->isCaptchaEnabled = $isCaptchaEnabled;
+    }
+
+    /**
+     * Process js Layout of block
+     *
+     * @param array $jsLayout
+     * @return array
+     */
+    public function process($jsLayout)
+    {
+        $key = 'paypal_payflowpro';
+        if ($this->isCaptchaEnabled->isCaptchaEnabledFor($key)) {
+            $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+            ['payment']['children']['payments-list']['children']['paypal-captcha']['children']
+            ['recaptcha']['settings'] = $this->captchaUiConfigResolver->get($key);
+        } else {
+            if (isset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+                ['payment']['children']['payments-list']['children']['paypal-captcha']['children']['recaptcha'])) {
+                unset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+                    ['payment']['children']['payments-list']['children']['paypal-captcha']['children']['recaptcha']);
+            }
+        }
+
+        return $jsLayout;
+    }
+}

--- a/ReCaptchaPaypal/Block/LayoutProcessor/Checkout/Onepage.php
+++ b/ReCaptchaPaypal/Block/LayoutProcessor/Checkout/Onepage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\ReCaptchaPaypal\Block\LayoutProcessor\Checkout;
 
 use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
+use Magento\Framework\Exception\InputException;
 use Magento\ReCaptchaUi\Model\IsCaptchaEnabledInterface;
 use Magento\ReCaptchaUi\Model\UiConfigResolverInterface;
 
@@ -39,10 +40,11 @@ class Onepage implements LayoutProcessorInterface
     }
 
     /**
-     * Process js Layout of block
+     * {@inheritdoc}
      *
      * @param array $jsLayout
      * @return array
+     * @throws InputException
      */
     public function process($jsLayout)
     {

--- a/ReCaptchaPaypal/Model/CheckoutConfigProvider.php
+++ b/ReCaptchaPaypal/Model/CheckoutConfigProvider.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ReCaptchaPaypal\Model;
+
+use Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\ReCaptchaUi\Model\IsCaptchaEnabledInterface;
+
+/**
+ * Adds reCaptcha configuration to checkout.
+ */
+class CheckoutConfigProvider implements ConfigProviderInterface
+{
+    /**
+     * @var IsCaptchaEnabledInterface
+     */
+    private $isCaptchaEnabled;
+
+    /**
+     * @param IsCaptchaEnabledInterface $isCaptchaEnabled
+     */
+    public function __construct(
+        IsCaptchaEnabledInterface $isCaptchaEnabled
+    ) {
+        $this->isCaptchaEnabled = $isCaptchaEnabled;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConfig()
+    {
+        return [
+            'recaptcha_paypal' => $this->isCaptchaEnabled->isCaptchaEnabledFor('paypal_payflowpro')
+        ];
+    }
+}

--- a/ReCaptchaPaypal/Observer/PayPalObserver.php
+++ b/ReCaptchaPaypal/Observer/PayPalObserver.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ReCaptchaPaypal\Observer;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ActionFlag;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\ReCaptchaUi\Model\IsCaptchaEnabledInterface;
+use Magento\ReCaptchaUi\Model\CaptchaResponseResolverInterface;
+use Magento\ReCaptchaUi\Model\ValidationConfigResolverInterface;
+use Magento\ReCaptchaValidationApi\Api\ValidatorInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * AjaxLoginObserver
+ */
+class PayPalObserver implements ObserverInterface
+{
+    /**
+     * @var CaptchaResponseResolverInterface
+     */
+    private $captchaResponseResolver;
+
+    /**
+     * @var ValidationConfigResolverInterface
+     */
+    private $validationConfigResolver;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $captchaValidator;
+
+    /**
+     * @var ActionFlag
+     */
+    private $actionFlag;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var IsCaptchaEnabledInterface
+     */
+    private $isCaptchaEnabled;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param CaptchaResponseResolverInterface $captchaResponseResolver
+     * @param ValidationConfigResolverInterface $validationConfigResolver
+     * @param ValidatorInterface $captchaValidator
+     * @param ActionFlag $actionFlag
+     * @param SerializerInterface $serializer
+     * @param IsCaptchaEnabledInterface $isCaptchaEnabled
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        CaptchaResponseResolverInterface $captchaResponseResolver,
+        ValidationConfigResolverInterface $validationConfigResolver,
+        ValidatorInterface $captchaValidator,
+        ActionFlag $actionFlag,
+        SerializerInterface $serializer,
+        IsCaptchaEnabledInterface $isCaptchaEnabled,
+        LoggerInterface $logger
+    ) {
+        $this->captchaResponseResolver = $captchaResponseResolver;
+        $this->validationConfigResolver = $validationConfigResolver;
+        $this->captchaValidator = $captchaValidator;
+        $this->actionFlag = $actionFlag;
+        $this->serializer = $serializer;
+        $this->isCaptchaEnabled = $isCaptchaEnabled;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Validates reCaptcha response.
+     *
+     * @param Observer $observer
+     * @return void
+     * @throws LocalizedException
+     */
+    public function execute(Observer $observer): void
+    {
+        $key = 'paypal_payflowpro';
+        if ($this->isCaptchaEnabled->isCaptchaEnabledFor($key)) {
+            /** @var Action $controller */
+            $controller = $observer->getControllerAction();
+            $request = $controller->getRequest();
+            $response = $controller->getResponse();
+
+            try {
+                $reCaptchaResponse = $this->captchaResponseResolver->resolve($request);
+            } catch (InputException $e) {
+                $reCaptchaResponse = '';
+                $this->logger->error($e);
+            }
+            $validationConfig = $this->validationConfigResolver->get($key);
+
+            $validationResult = $this->captchaValidator->isValid($reCaptchaResponse, $validationConfig);
+            if (false === $validationResult->isValid()) {
+                $this->actionFlag->set('', Action::FLAG_NO_DISPATCH, true);
+
+                $jsonPayload = $this->serializer->serialize([
+                    'success' => false,
+                    'error' => true,
+                    'error_messages' => $validationConfig->getValidationFailureMessage(),
+                ]);
+
+                $response->representJson($jsonPayload);
+            }
+        }
+    }
+}

--- a/ReCaptchaPaypal/README.md
+++ b/ReCaptchaPaypal/README.md
@@ -1,0 +1,1 @@
+Please refer to: https://github.com/magento/security-package

--- a/ReCaptchaPaypal/composer.json
+++ b/ReCaptchaPaypal/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "magento/module-re-captcha-paypal",
+    "description": "Google reCaptcha integration for Magento2 PayPal PayflowPro payment form",
+    "require": {
+        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "magento/module-re-captcha-frontend-ui": "*",
+        "magento/module-paypal-captcha": "*"
+    },
+    "type": "magento2-module",
+    "license": "OSL-3.0",
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\ReCaptchaPaypal\\": ""
+        }
+    }
+}

--- a/ReCaptchaPaypal/composer.json
+++ b/ReCaptchaPaypal/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/module-re-captcha-frontend-ui": "*",
-        "magento/module-paypal-captcha": "*"
+        "magento/module-re-captcha-validation-api": "*"
     },
     "type": "magento2-module",
     "license": "OSL-3.0",

--- a/ReCaptchaPaypal/composer.json
+++ b/ReCaptchaPaypal/composer.json
@@ -3,8 +3,11 @@
     "description": "Google reCaptcha integration for Magento2 PayPal PayflowPro payment form",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
+        "magento/framework": "*",
         "magento/module-re-captcha-frontend-ui": "*",
-        "magento/module-re-captcha-validation-api": "*"
+        "magento/module-re-captcha-ui": "*",
+        "magento/module-re-captcha-validation-api": "*",
+        "magento/module-checkout": "*"
     },
     "type": "magento2-module",
     "license": "OSL-3.0",

--- a/ReCaptchaPaypal/composer.json
+++ b/ReCaptchaPaypal/composer.json
@@ -4,7 +4,6 @@
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
-        "magento/module-re-captcha-frontend-ui": "*",
         "magento/module-re-captcha-ui": "*",
         "magento/module-re-captcha-validation-api": "*",
         "magento/module-checkout": "*"

--- a/ReCaptchaPaypal/etc/adminhtml/system.xml
+++ b/ReCaptchaPaypal/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
                 <field id="paypal_payflowpro" translate="label" type="select" sortOrder="200" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for PayPal PayflowPro payment form</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaPaypal/etc/adminhtml/system.xml
+++ b/ReCaptchaPaypal/etc/adminhtml/system.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="recaptcha_frontend">
+            <group id="type_for">
+                <field id="paypal_payflowpro" translate="label" type="select" sortOrder="200" showInDefault="1"
+                       showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Enable for PayPal PayflowPro payment form</label>
+                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/ReCaptchaPaypal/etc/config.xml
+++ b/ReCaptchaPaypal/etc/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <recaptcha_frontend>
+            <type_for>
+                <paypal_payflowpro/>
+            </type_for>
+        </recaptcha_frontend>
+    </default>
+</config>

--- a/ReCaptchaPaypal/etc/frontend/di.xml
+++ b/ReCaptchaPaypal/etc/frontend/di.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Checkout\Block\Onepage">
+        <arguments>
+            <argument name="layoutProcessors" xsi:type="array">
+                <item name="paypal_recaptcha" xsi:type="object">\Magento\ReCaptchaPaypal\Block\LayoutProcessor\Checkout\Onepage</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Checkout\Model\CompositeConfigProvider">
+        <arguments>
+            <argument name="configProviders" xsi:type="array">
+                <item name="recaptcha_config_provider" xsi:type="object">Magento\ReCaptchaPaypal\Model\CheckoutConfigProvider</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/ReCaptchaPaypal/etc/frontend/events.xml
+++ b/ReCaptchaPaypal/etc/frontend/events.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+
+    <event name="controller_action_predispatch_paypal_transparent_requestsecuretoken">
+        <observer name="recaptcha_on_paypal" instance="Magento\ReCaptchaPaypal\Observer\PayPalObserver"/>
+    </event>
+</config>

--- a/ReCaptchaPaypal/etc/module.xml
+++ b/ReCaptchaPaypal/etc/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_ReCaptchaPaypal"/>
+</config>

--- a/ReCaptchaPaypal/registration.php
+++ b/ReCaptchaPaypal/registration.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Magento_ReCaptchaPaypal',
+    __DIR__
+);

--- a/ReCaptchaPaypal/view/frontend/layout/checkout_index_index.xml
+++ b/ReCaptchaPaypal/view/frontend/layout/checkout_index_index.xml
@@ -29,7 +29,6 @@
                                                                             <item name="displayArea" xsi:type="string">additional-payment-fields</item>
                                                                             <item name="configSource" xsi:type="string">checkoutConfig</item>
                                                                             <item name="reCaptchaId" xsi:type="string">recaptcha-checkout-paypal-form</item>
-                                                                            <item name="zone" xsi:type="string">paypal</item>
                                                                         </item>
                                                                     </item>
                                                                 </item>

--- a/ReCaptchaPaypal/view/frontend/layout/checkout_index_index.xml
+++ b/ReCaptchaPaypal/view/frontend/layout/checkout_index_index.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="checkout.root">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="checkout" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="steps" xsi:type="array">
+                                    <item name="children" xsi:type="array">
+                                        <item name="billing-step" xsi:type="array">
+                                            <item name="children" xsi:type="array">
+                                                <item name="payment" xsi:type="array">
+                                                    <item name="children" xsi:type="array">
+                                                        <item name="payments-list" xsi:type="array">
+                                                            <item name="children" xsi:type="array">
+                                                                <item name="paypal-captcha" xsi:type="array">
+                                                                    <item name="children" xsi:type="array">
+                                                                        <item name="recaptcha" xsi:type="array">
+                                                                            <item name="component" xsi:type="string">Magento_ReCaptchaPaypal/js/reCaptchaPaypal</item>
+                                                                            <item name="displayArea" xsi:type="string">additional-payment-fields</item>
+                                                                            <item name="configSource" xsi:type="string">checkoutConfig</item>
+                                                                            <item name="reCaptchaId" xsi:type="string">recaptcha-checkout-paypal-form</item>
+                                                                            <item name="zone" xsi:type="string">paypal</item>
+                                                                        </item>
+                                                                    </item>
+                                                                </item>
+                                                            </item>
+                                                        </item>
+                                                    </item>
+                                                </item>
+                                            </item>
+                                        </item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/ReCaptchaPaypal/view/frontend/requirejs-config.js
+++ b/ReCaptchaPaypal/view/frontend/requirejs-config.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// eslint-disable-next-line no-unused-vars
+var config = {
+    config: {
+        mixins: {
+            'Magento_Paypal/js/view/payment/method-renderer/payflowpro-method': {
+                'Magento_ReCaptchaPaypal/js/payflowpro-method-mixin': true
+            }
+        }
+    }
+};

--- a/ReCaptchaPaypal/view/frontend/web/js/payflowpro-method-mixin.js
+++ b/ReCaptchaPaypal/view/frontend/web/js/payflowpro-method-mixin.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'jquery',
+    'Magento_Checkout/js/model/payment/additional-validators'
+], function ($, additionalValidators) {
+    'use strict';
+
+    return function (originalComponent) {
+        return originalComponent.extend({
+            /**
+             * Initializes reCaptcha
+             */
+            placeOrder: function () {
+                var original = this._super.bind(this),
+                    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+                    isEnabledForPaypal = window.checkoutConfig.recaptcha_paypal,
+                    // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+                    paymentFormSelector = $('#co-payment-form'),
+                    startEvent = 'captcha:startExecute',
+                    endEvent = 'captcha:endExecute';
+
+                if (!this.validateHandler() || !additionalValidators.validate() || !isEnabledForPaypal) {
+                    return original();
+                }
+
+                paymentFormSelector.off(endEvent).on(endEvent, function () {
+                    original();
+                    paymentFormSelector.off(endEvent);
+                });
+
+                paymentFormSelector.trigger(startEvent);
+            }
+        });
+    };
+});

--- a/ReCaptchaPaypal/view/frontend/web/js/reCaptchaPaypal.js
+++ b/ReCaptchaPaypal/view/frontend/web/js/reCaptchaPaypal.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define(
+    [
+        'Magento_ReCaptchaFrontendUi/js/reCaptcha',
+        'jquery'
+    ],
+    function (Component, $) {
+        'use strict';
+
+        return Component.extend({
+
+            /**
+             * Recaptcha callback
+             * @param {String} token
+             */
+            reCaptchaCallback: function (token) {
+                this.tokenField.value = token;
+                this.$parentForm.trigger('captcha:endExecute');
+            },
+
+            /**
+             * Initialize parent form.
+             *
+             * @param {Object} parentForm
+             * @param {String} widgetId
+             */
+            initParentForm: function (parentForm, widgetId) {
+                var me = this;
+
+                parentForm.on('captcha:startExecute', function (event) {
+                    if (!me.tokenField.value && me.getIsInvisibleRecaptcha()) {
+                        // eslint-disable-next-line no-undef
+                        grecaptcha.execute(widgetId);
+                        event.preventDefault(event);
+                        event.stopImmediatePropagation();
+                    } else {
+                        me.$parentForm.trigger('captcha:endExecute');
+                    }
+                });
+
+                // Create a virtual token field
+                this.tokenField = $('<input type="text" name="token" style="display: none" />')[0];
+                this.$parentForm = parentForm;
+                parentForm.append(this.tokenField);
+            }
+        });
+    }
+);

--- a/ReCaptchaReview/etc/adminhtml/system.xml
+++ b/ReCaptchaReview/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
                 <field id="product_review" translate="label" type="select" sortOrder="150" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Product Review</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaSendFriend/etc/adminhtml/system.xml
+++ b/ReCaptchaSendFriend/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
                 <field id="sendfriend" translate="label" type="select" sortOrder="170" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable for Send To Friend</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaUser/etc/adminhtml/system.xml
+++ b/ReCaptchaUser/etc/adminhtml/system.xml
@@ -13,13 +13,13 @@
                 <field id="user_login" translate="label" type="select" sortOrder="100" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable for Login</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
 
                 <field id="user_forgot_password" translate="label" type="select" sortOrder="110" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable for Forgot Password</label>
-                    <source_model>Magento\ReCaptchaApi\Model\OptionSource\Type</source_model>
+                    <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaVersion2Checkbox/etc/di.xml
+++ b/ReCaptchaVersion2Checkbox/etc/di.xml
@@ -23,7 +23,7 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="Magento\ReCaptchaApi\Model\OptionSource\Type">
+    <virtualType name="Magento\ReCaptchaAdminUi\Model\OptionSource\Type">
         <arguments>
             <argument name="options" xsi:type="array">
                 <item name="recaptcha" xsi:type="array">

--- a/ReCaptchaVersion2Invisible/etc/di.xml
+++ b/ReCaptchaVersion2Invisible/etc/di.xml
@@ -23,7 +23,7 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="Magento\ReCaptchaApi\Model\OptionSource\Type">
+    <virtualType name="Magento\ReCaptchaAdminUi\Model\OptionSource\Type">
         <arguments>
             <argument name="options" xsi:type="array">
                 <item name="invisible" xsi:type="array">

--- a/ReCaptchaVersion3Invisible/etc/di.xml
+++ b/ReCaptchaVersion3Invisible/etc/di.xml
@@ -23,7 +23,7 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="Magento\ReCaptchaApi\Model\OptionSource\Type">
+    <virtualType name="Magento\ReCaptchaAdminUi\Model\OptionSource\Type">
         <arguments>
             <argument name="options" xsi:type="array">
                 <item name="recaptcha_v3" xsi:type="array">

--- a/_metapackage/composer.json
+++ b/_metapackage/composer.json
@@ -29,6 +29,7 @@
         "magento/module-re-captcha-customer": "*",
         "magento/module-re-captcha-frontend-ui": "*",
         "magento/module-re-captcha-newsletter": "*",
+        "magento/module-re-captcha-paypal": "*",
         "magento/module-re-captcha-review": "*",
         "magento/module-re-captcha-send-friend": "*",
         "magento/module-re-captcha-ui": "*",


### PR DESCRIPTION
https://github.com/magento/PayPalReCaptcha is built on top of https://github.com/magento/magespecialist_ReCaptcha

Since  https://github.com/magento/magespecialist_ReCaptcha is moved to https://github.com/magento/security-package it will be logical to move there https://github.com/magento/PayPalReCaptcha  as well for the sake of decreasing release efforts in the future.


Related PR infra: https://github.com/magento/magento2-infrastructure/pull/1156