### PR TITLE
fix authy 2fa trusted device

### DIFF
--- a/TwoFactorAuth/view/adminhtml/web/js/authy/auth.js
+++ b/TwoFactorAuth/view/adminhtml/web/js/authy/auth.js
@@ -100,10 +100,7 @@ define([
             this.selectedMethod('code');
 
             if (via !== 'token') {
-                $.getJSON(
-                    this.getTokenRequestUrl() + '?via=' +
-                    via + '&tfa_trust_device=' + (me.trustThisDevice() ? 1 : 0)
-                )
+                $.getJSON(this.getTokenRequestUrl() + '?via=' + via)
                     .fail(function () {
                         error.display('There was an error trying to contact Authy services');
                         me.switchAnotherMethod();
@@ -144,7 +141,7 @@ define([
 
             this.stopWaitingOnetouchApproval();
 
-            $.getJSON(this.getOneTouchUrl() + '?tfa_trust_device=' + (me.trustThisDevice() ? 1 : 0))
+            $.getJSON(this.getOneTouchUrl())
                 .done(function () {
                     me.waitForOneTouchApproval();
                 })
@@ -162,7 +159,7 @@ define([
 
             this.waitingText('Waiting for approval...');
 
-            $.getJSON(this.getVerifyOneTouchUrl())
+            $.getJSON(this.getVerifyOneTouchUrl() + '?tfa_trust_device=' + (me.trustThisDevice() ? 1 : 0))
                 .done(function (res) {
                     if (res.status === 'retry') {
                         me.waitForOneTouchApprovalTimeout = window.setTimeout(function () {
@@ -202,7 +199,8 @@ define([
             this.waitingText('Please wait...');
 
             $.post(this.getPostUrl(), {
-                'tfa_code': this.tokenCode
+                'tfa_code': this.tokenCode,
+                'tfa_trust_device': me.trustThisDevice() ? 1 : 0
             })
                 .done(function (res) {
                     if (res.success) {

--- a/TwoFactorAuth/view/adminhtml/web/template/authy/auth.html
+++ b/TwoFactorAuth/view/adminhtml/web/template/authy/auth.html
@@ -42,6 +42,11 @@
                     class="action-choose">
                 <span data-bind='i18n: "Send me a code via phone call"'></span>
             </button>
+
+            <br/><br/>
+            <!-- ko foreach: getRegion('trust-device') -->
+            <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
         </div>
 
         <div class="tfa-waitbox" visible='(selectedMethod() === "onetouch") && !success()'>
@@ -75,11 +80,7 @@
             </div>
         </div>
 
-        <div visible='(selectedMethod() === "code") && !success()'>
-            <!-- ko foreach: getRegion('trust-device') -->
-            <!-- ko template: getTemplate() --><!-- /ko -->
-            <!--/ko-->
-        </div><br/>
+        <br/>
 
         <div class="form-actions tfa-authy-request-code" visible='(selectedMethod() === "code") && !success()'>
             <div class="actions">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

- 2FA trusted device wasn't working for Authy provider. tfa_trust_device variable was being passed through the wrong functions, it needs to be passed through the functions that validate the approval or verify the code.
- Also moved the trust-device template so it can be selected before a verification option is selected, One Touch logins can now have the option to select Remember Me.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)

- Not Relevant

<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
- Not Relevant
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
