### PR TITLE
security-package/issues/104: "Enable Invisible reCAPTCHA in Newsletter Subscription" should not be shown for not supported types of reCAPTCHA.

### DIFF
--- a/ReCaptchaAdminUi/etc/adminhtml/system.xml
+++ b/ReCaptchaAdminUi/etc/adminhtml/system.xml
@@ -109,7 +109,7 @@
                        showInStore="0" canRestore="1">
                     <label>Score Threshold</label>
                     <depends>
-                        <field id="recaptcha/general/type">recaptcha_v3</field>
+                        <field id="recaptcha/frontend/type">recaptcha_v3</field>
                     </depends>
                     <comment>From 0.0 to 1.0, where 0.0 is absolutely a robot and 1.0 is a human.</comment>
                 </field>

--- a/ReCaptchaNewsletter/etc/adminhtml/system.xml
+++ b/ReCaptchaNewsletter/etc/adminhtml/system.xml
@@ -13,10 +13,11 @@
                 <field id="enabled_for_newsletter" translate="label" type="select" sortOrder="250" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Use invisible ReCaptcha in newsletter</label>
-                    <comment>Requires an Invisible ReCaptcha v2 or ReCaptcha v3 key. If enabled, a badge will be displayed in every page.</comment>
+                    <comment>Requires an Invisible reCAPTCHA v2 or v3 key.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
+                        <field id="recaptcha/frontend/type" negative="1">recaptcha</field>
                     </depends>
                 </field>
             </group>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed enabled_for_newsletter and score_threshold fields visibility for frontend area.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/security-package/issues/104

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
