### PR TITLE
security-package/issues/121: Fix missed variable.

### DIFF
--- a/ReCaptcha/Model/CaptchaValidator.php
+++ b/ReCaptcha/Model/CaptchaValidator.php
@@ -32,8 +32,9 @@ class CaptchaValidator implements CaptchaValidatorInterface
             // @codingStandardsIgnoreEmd
 
             if ($validationConfig->getCaptchaType() === 'recaptcha_v3') {
-                if (isset($options['threshold'])) {
-                    $reCaptcha->setScoreThreshold($validationConfig->getScoreThreshold());
+                $scoreThreshold = $validationConfig->getScoreThreshold();
+                if ($validationConfig->getCaptchaType() === 'recaptcha_v3' && $scoreThreshold !== null) {
+                    $reCaptcha->setScoreThreshold($scoreThreshold);
                 }
             }
             $res = $reCaptcha->verify($reCaptchaResponse, $validationConfig->getRemoteIp());


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed missed variable $options of method

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/security-package#121: ReCaptcha/Model/CaptchaValidator.php:35 Avoid unused local variables such as '$options'.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
