### PR TITLE
security-package/issues/132:  $validationErrors is undefined in \Magento\ReCaptchaValidation\Model\Validator

### DIFF
--- a/ReCaptchaValidation/Model/Validator.php
+++ b/ReCaptchaValidation/Model/Validator.php
@@ -60,14 +60,13 @@ class Validator implements ValidatorInterface
         }
         $result = $reCaptcha->verify($reCaptchaResponse, $validationConfig->getRemoteIp());
 
-        if ($result->isSuccess()) {
-            $validationResult = $this->validationResultFactory->create(['errors' => []]);
-        } else {
+        $validationErrors = [];
+        if (!$result->isSuccess()) {
             foreach ($result->getErrorCodes() as $errorCode) {
                 $validationErrors[] = $this->errorMessages->getErrorMessage($errorCode);
             }
-            $validationResult = $this->validationResultFactory->create(['errors' => $validationErrors]);
         }
-        return $validationResult;
+
+        return $this->validationResultFactory->create(['errors' => $validationErrors]);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/security-package/issues/132:  $validationErrors is undefined in \Magento\ReCaptchaValidation\Model\Validator

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
