### PR TITLE
Refactoring.

### DIFF
--- a/ReCaptchaCustomer/Model/AjaxLogin/CaptchaResponseResolver.php
+++ b/ReCaptchaCustomer/Model/AjaxLogin/CaptchaResponseResolver.php
@@ -32,7 +32,7 @@ class CaptchaResponseResolver implements CaptchaResponseResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @param RequestInterface|PlainTextRequestInterface $request
      * @return string

--- a/ReCaptchaValidation/Model/Validator.php
+++ b/ReCaptchaValidation/Model/Validator.php
@@ -9,10 +9,10 @@ namespace Magento\ReCaptchaValidation\Model;
 
 use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
-use Magento\ReCaptchaValidationApi\Api\ValidatorInterface;
 use Magento\ReCaptchaValidationApi\Api\Data\ValidationConfigInterface;
-use Magento\ReCaptchaValidationApi\Model\ErrorMessages;
-use ReCaptcha\ReCaptcha;
+use Magento\ReCaptchaValidationApi\Api\ValidatorInterface;
+use Magento\ReCaptchaValidationApi\Model\ErrorMessagesProvider;
+use ReCaptcha\ReCaptchaFactory;
 
 /**
  * @inheritdoc
@@ -25,20 +25,28 @@ class Validator implements ValidatorInterface
     private $validationResultFactory;
 
     /**
-     * @var ErrorMessages
+     * @var ErrorMessagesProvider
      */
-    private $errorMessages;
+    private $errorMessagesProvider;
+
+    /**
+     * @var ReCaptchaFactory
+     */
+    private $reCaptchaFactory;
 
     /**
      * @param ValidationResultFactory $validationResultFactory
-     * @param ErrorMessages $errorMessages
+     * @param ErrorMessagesProvider $errorMessagesProvider
+     * @param ReCaptchaFactory $reCaptchaFactory
      */
     public function __construct(
         ValidationResultFactory $validationResultFactory,
-        ErrorMessages $errorMessages
+        ErrorMessagesProvider $errorMessagesProvider,
+        ReCaptchaFactory $reCaptchaFactory
     ) {
         $this->validationResultFactory = $validationResultFactory;
-        $this->errorMessages = $errorMessages;
+        $this->errorMessagesProvider = $errorMessagesProvider;
+        $this->reCaptchaFactory = $reCaptchaFactory;
     }
 
     /**
@@ -49,11 +57,7 @@ class Validator implements ValidatorInterface
         ValidationConfigInterface $validationConfig
     ): ValidationResult {
         $secret = $validationConfig->getPrivateKey();
-
-        // @codingStandardsIgnoreStart
-        $reCaptcha = new ReCaptcha($secret);
-        // @codingStandardsIgnoreEnd
-
+        $reCaptcha = $this->reCaptchaFactory->create(['secret' => $secret]);
         $extensionAttributes = $validationConfig->getExtensionAttributes();
         if ($extensionAttributes && (null !== $extensionAttributes->getScoreThreshold())) {
             $reCaptcha->setScoreThreshold($extensionAttributes->getScoreThreshold());
@@ -64,7 +68,7 @@ class Validator implements ValidatorInterface
             $validationResult = $this->validationResultFactory->create(['errors' => []]);
         } else {
             foreach ($result->getErrorCodes() as $errorCode) {
-                $validationErrors[] = $this->errorMessages->getErrorMessage($errorCode);
+                $validationErrors[] = $this->errorMessagesProvider->getErrorMessage($errorCode);
             }
             $validationResult = $this->validationResultFactory->create(['errors' => $validationErrors]);
         }

--- a/ReCaptchaValidationApi/Model/ErrorMessagesProvider.php
+++ b/ReCaptchaValidationApi/Model/ErrorMessagesProvider.php
@@ -12,7 +12,7 @@ namespace Magento\ReCaptchaValidationApi\Model;
  *
  * @api Class name should be used in DI for adding new validation errors
  */
-class ErrorMessages
+class ErrorMessagesProvider
 {
     /**
      * @var array

--- a/ReCaptchaValidationApi/etc/di.xml
+++ b/ReCaptchaValidationApi/etc/di.xml
@@ -7,7 +7,7 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\ReCaptchaValidationApi\Model\ErrorMessages">
+    <type name="Magento\ReCaptchaValidationApi\Model\ErrorMessagesProvider">
         <arguments>
             <argument name="errors" xsi:type="array">
                 <item name="invalid-json" xsi:type="string" translatable="true">Invalid JSON received.</item>


### PR DESCRIPTION
https://github.com/magento/security-package/blob/1.0-develop/ReCaptchaValidationApi/Model/ErrorMessages.php#L8 it does not look like a Model but more like service class

A factory should be used instead of `new` to provide a mocking mechanism for tests https://github.com/magento/security-package/blob/1.0-develop/ReCaptchaValidation/Model/Validator.php#L54

https://github.com/magento/security-package/blob/1.0-develop/ReCaptchaValidation/Model/Validator.php#L63-L69 could be simplified -> create validation errors array and after that create a result object

https://github.com/magento/security-package/blob/1.0-develop/ReCaptchaCustomer/Model/AjaxLogin/CaptchaResponseResolver.php#L35 incorrect doc block formatting