### PR TITLE
security-package/issues/148: "Language code" does not work for reCAPTCHA v2 ("I am not a robot")

### DIFF
--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -56,7 +56,7 @@ define(
                 element.async = true;
                 element.src = 'https://www.google.com/recaptcha/api.js' +
                     '?onload=globalOnRecaptchaOnLoadCallback&render=explicit' +
-                    (this.settings.lang ? '&hl=' + this.settings.lang : '');
+                    (this.settings.rendering.lang ? '&hl=' + this.settings.rendering.lang : '');
 
                 scriptTag.parentNode.insertBefore(element, scriptTag);
 

--- a/ReCaptchaVersion2Checkbox/Model/Adminhtml/UiConfigProvider.php
+++ b/ReCaptchaVersion2Checkbox/Model/Adminhtml/UiConfigProvider.php
@@ -42,8 +42,8 @@ class UiConfigProvider implements UiConfigProviderInterface
         $config = [
             'rendering' => [
                 'sitekey' => $this->getPublicKey(),
-                'theme' => $this->getTheme(),
                 'size' => $this->getSize(),
+                'theme' => $this->getTheme(),
                 'lang' => $this->getLanguageCode(),
             ],
             'invisible' => false,

--- a/ReCaptchaVersion2Checkbox/Model/Frontend/UiConfigProvider.php
+++ b/ReCaptchaVersion2Checkbox/Model/Frontend/UiConfigProvider.php
@@ -43,8 +43,8 @@ class UiConfigProvider implements UiConfigProviderInterface
         $config = [
             'rendering' => [
                 'sitekey' => $this->getPublicKey(),
-                'theme' => $this->getTheme(),
                 'size' => $this->getSize(),
+                'theme' => $this->getTheme(),
                 'lang' => $this->getLanguageCode(),
             ],
             'invisible' => false,

--- a/ReCaptchaVersion2Checkbox/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion2Checkbox/etc/adminhtml/system.xml
@@ -17,16 +17,16 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
 
-                <field id="theme" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0"
-                       showInStore="0" canRestore="1">
-                    <label>Theme</label>
-                    <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Theme</source_model>
-                </field>
-
-                <field id="size" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0"
+                <field id="size" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0"
                        showInStore="0" canRestore="1">
                     <label>Size</label>
                     <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Size</source_model>
+                </field>
+
+                <field id="theme" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Theme</source_model>
                 </field>
 
                 <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0"
@@ -60,16 +60,16 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
 
-                <field id="theme" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1"
-                       showInStore="0" canRestore="1">
-                    <label>Theme</label>
-                    <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Theme</source_model>
-                </field>
-
-                <field id="size" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1"
+                <field id="size" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1"
                        showInStore="0" canRestore="1">
                     <label>Size</label>
                     <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Size</source_model>
+                </field>
+
+                <field id="theme" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion2Checkbox\Model\OptionSource\Theme</source_model>
                 </field>
 
                 <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"

--- a/ReCaptchaVersion2Invisible/Model/Adminhtml/UiConfigProvider.php
+++ b/ReCaptchaVersion2Invisible/Model/Adminhtml/UiConfigProvider.php
@@ -17,6 +17,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_backend/type_invisible/public_key';
     private const XML_PATH_POSITION = 'recaptcha_backend/type_invisible/position';
+    private const XML_PATH_THEME = 'recaptcha_backend/type_invisible/theme';
     private const XML_PATH_LANGUAGE_CODE = 'recaptcha_backend/type_invisible/lang';
 
     /**
@@ -43,6 +44,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'theme' => $this->getTheme(),
                 'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
@@ -69,6 +71,18 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION
+        );
+    }
+
+    /**
+     * Get theme
+     *
+     * @return string
+     */
+    private function getTheme(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_THEME
         );
     }
 

--- a/ReCaptchaVersion2Invisible/Model/Adminhtml/UiConfigProvider.php
+++ b/ReCaptchaVersion2Invisible/Model/Adminhtml/UiConfigProvider.php
@@ -17,6 +17,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_backend/type_invisible/public_key';
     private const XML_PATH_POSITION = 'recaptcha_backend/type_invisible/position';
+    private const XML_PATH_LANGUAGE_CODE = 'recaptcha_backend/type_invisible/lang';
 
     /**
      * @var ScopeConfigInterface
@@ -41,7 +42,8 @@ class UiConfigProvider implements UiConfigProviderInterface
             'rendering' => [
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
-                'size' => 'invisible'
+                'size' => 'invisible',
+                'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
         ];
@@ -67,6 +69,18 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION
+        );
+    }
+
+    /**
+     * Get language code
+     *
+     * @return string
+     */
+    private function getLanguageCode(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_LANGUAGE_CODE
         );
     }
 }

--- a/ReCaptchaVersion2Invisible/Model/Frontend/UiConfigProvider.php
+++ b/ReCaptchaVersion2Invisible/Model/Frontend/UiConfigProvider.php
@@ -18,6 +18,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_frontend/type_invisible/public_key';
     private const XML_PATH_POSITION = 'recaptcha_frontend/type_invisible/position';
+    private const XML_PATH_THEME = 'recaptcha_frontend/type_invisible/theme';
     private const XML_PATH_LANGUAGE_CODE = 'recaptcha_frontend/type_invisible/lang';
 
     /**
@@ -44,6 +45,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'theme' => $this->getTheme(),
                 'lang' => $this->getLanguageCode()
             ],
             'invisible' => true,
@@ -70,6 +72,19 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION,
+            ScopeInterface::SCOPE_WEBSITE
+        );
+    }
+
+    /**
+     * Get theme
+     *
+     * @return string
+     */
+    private function getTheme(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_THEME,
             ScopeInterface::SCOPE_WEBSITE
         );
     }

--- a/ReCaptchaVersion2Invisible/Model/Frontend/UiConfigProvider.php
+++ b/ReCaptchaVersion2Invisible/Model/Frontend/UiConfigProvider.php
@@ -18,6 +18,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_frontend/type_invisible/public_key';
     private const XML_PATH_POSITION = 'recaptcha_frontend/type_invisible/position';
+    private const XML_PATH_LANGUAGE_CODE = 'recaptcha_frontend/type_invisible/lang';
 
     /**
      * @var ScopeConfigInterface
@@ -42,7 +43,8 @@ class UiConfigProvider implements UiConfigProviderInterface
             'rendering' => [
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
-                'size' => 'invisible'
+                'size' => 'invisible',
+                'lang' => $this->getLanguageCode()
             ],
             'invisible' => true,
         ];
@@ -69,6 +71,19 @@ class UiConfigProvider implements UiConfigProviderInterface
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION,
             ScopeInterface::SCOPE_WEBSITE
+        );
+    }
+
+    /**
+     * Get language code
+     *
+     * @return string
+     */
+    private function getLanguageCode(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_LANGUAGE_CODE,
+            ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
@@ -23,7 +23,13 @@
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0"
+                <field id="theme" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Theme</source_model>
+                </field>
+
+                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0"
                        showInStore="0" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
@@ -32,7 +38,7 @@
                 ]]></comment>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>
@@ -60,7 +66,13 @@
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+                <field id="theme" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Theme</source_model>
+                </field>
+
+                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
@@ -69,7 +81,7 @@
                 ]]></comment>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>

--- a/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
@@ -23,7 +23,16 @@
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="40" showInDefault="1"
+                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Language Code</label>
+                    <comment><![CDATA[
+                        Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See
+                        <a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language Codes</a>.
+                ]]></comment>
+                </field>
+
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>
@@ -51,7 +60,16 @@
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="40" showInDefault="1"
+                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Language Code</label>
+                    <comment><![CDATA[
+                        Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See
+                        <a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language Codes</a>.
+                ]]></comment>
+                </field>
+
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>

--- a/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
@@ -23,8 +23,8 @@
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
-                       showInStore="1" canRestore="1">
+                <field id="lang" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
                         Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See

--- a/ReCaptchaVersion2Invisible/etc/config.xml
+++ b/ReCaptchaVersion2Invisible/etc/config.xml
@@ -12,6 +12,8 @@
             <type_invisible>
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <position>inline</position>
+                <theme>light</theme>
+                <lang/>
                 <validation_failure_message>reCAPTCHA verification failed</validation_failure_message>
             </type_invisible>
         </recaptcha_backend>
@@ -19,6 +21,8 @@
             <type_invisible>
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <position>inline</position>
+                <theme>light</theme>
+                <lang/>
                 <validation_failure_message>reCAPTCHA verification failed</validation_failure_message>
             </type_invisible>
         </recaptcha_frontend>

--- a/ReCaptchaVersion2Invisible/etc/di.xml
+++ b/ReCaptchaVersion2Invisible/etc/di.xml
@@ -52,4 +52,19 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Theme"
+                 type="Magento\ReCaptchaAdminUi\Model\OptionSource">
+        <arguments>
+            <argument name="options" xsi:type="array">
+                <item name="light" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Light Theme</item>
+                    <item name="value" xsi:type="string">light</item>
+                </item>
+                <item name="dark" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Dark Theme</item>
+                    <item name="value" xsi:type="string">dark</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/ReCaptchaVersion3Invisible/Model/Adminhtml/UiConfigProvider.php
+++ b/ReCaptchaVersion3Invisible/Model/Adminhtml/UiConfigProvider.php
@@ -17,6 +17,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_backend/type_recaptcha_v3/public_key';
     private const XML_PATH_POSITION = 'recaptcha_backend/type_recaptcha_v3/position';
+    private const XML_PATH_THEME = 'recaptcha_backend/type_recaptcha_v3/theme';
     private const XML_PATH_LANGUAGE_CODE = 'recaptcha_backend/type_recaptcha_v3/lang';
 
     /**
@@ -43,6 +44,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'theme' => $this->getTheme(),
                 'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
@@ -69,6 +71,18 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION
+        );
+    }
+
+    /**
+     * Get theme
+     *
+     * @return string
+     */
+    private function getTheme(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_THEME
         );
     }
 

--- a/ReCaptchaVersion3Invisible/Model/Adminhtml/UiConfigProvider.php
+++ b/ReCaptchaVersion3Invisible/Model/Adminhtml/UiConfigProvider.php
@@ -17,6 +17,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_backend/type_recaptcha_v3/public_key';
     private const XML_PATH_POSITION = 'recaptcha_backend/type_recaptcha_v3/position';
+    private const XML_PATH_LANGUAGE_CODE = 'recaptcha_backend/type_recaptcha_v3/lang';
 
     /**
      * @var ScopeConfigInterface
@@ -42,6 +43,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
         ];
@@ -67,6 +69,18 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION
+        );
+    }
+
+    /**
+     * Get language code
+     *
+     * @return string
+     */
+    private function getLanguageCode(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_LANGUAGE_CODE
         );
     }
 }

--- a/ReCaptchaVersion3Invisible/Model/Frontend/UiConfigProvider.php
+++ b/ReCaptchaVersion3Invisible/Model/Frontend/UiConfigProvider.php
@@ -18,6 +18,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_frontend/type_recaptcha_v3/public_key';
     private const XML_PATH_POSITION = 'recaptcha_frontend/type_recaptcha_v3/position';
+    private const XML_PATH_THEME = 'recaptcha_frontend/type_recaptcha_v3/theme';
     private const XML_PATH_LANGUAGE_CODE = 'recaptcha_frontend/type_recaptcha_v3/lang';
 
     /**
@@ -44,6 +45,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'theme' => $this->getTheme(),
                 'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
@@ -70,6 +72,19 @@ class UiConfigProvider implements UiConfigProviderInterface
     {
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION,
+            ScopeInterface::SCOPE_WEBSITE
+        );
+    }
+
+    /**
+     * Get theme
+     *
+     * @return string
+     */
+    private function getTheme(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_THEME,
             ScopeInterface::SCOPE_WEBSITE
         );
     }

--- a/ReCaptchaVersion3Invisible/Model/Frontend/UiConfigProvider.php
+++ b/ReCaptchaVersion3Invisible/Model/Frontend/UiConfigProvider.php
@@ -18,6 +18,7 @@ class UiConfigProvider implements UiConfigProviderInterface
 {
     private const XML_PATH_PUBLIC_KEY = 'recaptcha_frontend/type_recaptcha_v3/public_key';
     private const XML_PATH_POSITION = 'recaptcha_frontend/type_recaptcha_v3/position';
+    private const XML_PATH_LANGUAGE_CODE = 'recaptcha_frontend/type_recaptcha_v3/lang';
 
     /**
      * @var ScopeConfigInterface
@@ -43,6 +44,7 @@ class UiConfigProvider implements UiConfigProviderInterface
                 'sitekey' => $this->getPublicKey(),
                 'badge' => $this->getInvisibleBadgePosition(),
                 'size' => 'invisible',
+                'lang'=> $this->getLanguageCode()
             ],
             'invisible' => true,
         ];
@@ -69,6 +71,19 @@ class UiConfigProvider implements UiConfigProviderInterface
         return (string)$this->scopeConfig->getValue(
             self::XML_PATH_POSITION,
             ScopeInterface::SCOPE_WEBSITE
+        );
+    }
+
+    /**
+     * Get language code
+     *
+     * @return string
+     */
+    private function getLanguageCode(): string
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::XML_PATH_LANGUAGE_CODE,
+            ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
@@ -33,7 +33,16 @@
                     <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
+                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Language Code</label>
+                    <comment><![CDATA[
+                        Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See
+                        <a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language Codes</a>.
+                ]]></comment>
+                </field>
+
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>
@@ -76,7 +85,16 @@
                 ]]></comment>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="50" showInDefault="1"
+                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Language Code</label>
+                    <comment><![CDATA[
+                        Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See
+                        <a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language Codes</a>.
+                ]]></comment>
+                </field>
+
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>

--- a/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
@@ -33,7 +33,13 @@
                     <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0"
+                <field id="theme" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Theme</source_model>
+                </field>
+
+                <field id="lang" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="0"
                        showInStore="0" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
@@ -42,7 +48,7 @@
                 ]]></comment>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="70" showInDefault="1"
                        showInWebsite="0" showInStore="0" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>
@@ -80,7 +86,13 @@
                     <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
+                <field id="theme" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1"
+                       showInStore="0" canRestore="1">
+                    <label>Theme</label>
+                    <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Theme</source_model>
+                </field>
+
+                <field id="lang" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
@@ -89,7 +101,7 @@
                 ]]></comment>
                 </field>
 
-                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="60" showInDefault="1"
+                <field id="validation_failure_message" translate="label" type="textarea" sortOrder="70" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>reCAPTCHA Validation Failure Message</label>
                 </field>

--- a/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
@@ -33,8 +33,8 @@
                     <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Position</source_model>
                 </field>
 
-                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
-                       showInStore="1" canRestore="1">
+                <field id="lang" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
                     <label>Language Code</label>
                     <comment><![CDATA[
                         Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. See

--- a/ReCaptchaVersion3Invisible/etc/config.xml
+++ b/ReCaptchaVersion3Invisible/etc/config.xml
@@ -13,6 +13,8 @@
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <score_threshold>0.5</score_threshold>
                 <position>inline</position>
+                <theme>light</theme>
+                <lang/>
                 <validation_failure_message>You cannot proceed with such operation, your reCAPTCHA reputation is too low.</validation_failure_message>
             </type_recaptcha_v3>
         </recaptcha_backend>
@@ -21,6 +23,8 @@
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <score_threshold>0.5</score_threshold>
                 <position>inline</position>
+                <theme>light</theme>
+                <lang/>
                 <validation_failure_message>You cannot proceed with such operation, your reCAPTCHA reputation is too low.</validation_failure_message>
             </type_recaptcha_v3>
         </recaptcha_frontend>

--- a/ReCaptchaVersion3Invisible/etc/di.xml
+++ b/ReCaptchaVersion3Invisible/etc/di.xml
@@ -52,4 +52,19 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Theme"
+                 type="Magento\ReCaptchaAdminUi\Model\OptionSource">
+        <arguments>
+            <argument name="options" xsi:type="array">
+                <item name="light" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Light Theme</item>
+                    <item name="value" xsi:type="string">light</item>
+                </item>
+                <item name="dark" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Dark Theme</item>
+                    <item name="value" xsi:type="string">dark</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Updated JS for reCaptcha.js, fixed support languages for reCAPTCHA v2 ("I am not a robot").

Added Languages support for ReCaptcha version v2 Invisible & v3.



<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/security-package#148: "Language code" does not work for reCAPTCHA v2 ("I am not a robot") and is missed for reCAPTCHA v2-3 Invisible

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
