### PR TITLE
security-package/issues/170: Renamed error message.

### DIFF
--- a/ReCaptchaContact/Test/Integration/ContactFormTest.php
+++ b/ReCaptchaContact/Test/Integration/ContactFormTest.php
@@ -150,7 +150,7 @@ class ContactFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Can not resolve reCAPTCHA parameter.');
+        $this->expectExceptionMessage('reCapctha is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaContact/Test/Integration/ContactFormTest.php
+++ b/ReCaptchaContact/Test/Integration/ContactFormTest.php
@@ -150,7 +150,7 @@ class ContactFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('reCapctha is required.');
+        $this->expectExceptionMessage('reCAPTCHA is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/CreateCustomerFormTest.php
+++ b/ReCaptchaCustomer/Test/Integration/CreateCustomerFormTest.php
@@ -174,7 +174,7 @@ class CreateCustomerFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('reCapctha is required.');
+        $this->expectExceptionMessage('reCAPTCHA is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/CreateCustomerFormTest.php
+++ b/ReCaptchaCustomer/Test/Integration/CreateCustomerFormTest.php
@@ -174,7 +174,7 @@ class CreateCustomerFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Can not resolve reCAPTCHA parameter.');
+        $this->expectExceptionMessage('reCapctha is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/ForgotPasswordFormTest.php
+++ b/ReCaptchaCustomer/Test/Integration/ForgotPasswordFormTest.php
@@ -167,7 +167,7 @@ class ForgotPasswordFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Can not resolve reCAPTCHA parameter.');
+        $this->expectExceptionMessage('reCapctha is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/ForgotPasswordFormTest.php
+++ b/ReCaptchaCustomer/Test/Integration/ForgotPasswordFormTest.php
@@ -167,7 +167,7 @@ class ForgotPasswordFormTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('reCapctha is required.');
+        $this->expectExceptionMessage('reCAPTCHA is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/LoginFromTest.php
+++ b/ReCaptchaCustomer/Test/Integration/LoginFromTest.php
@@ -166,7 +166,7 @@ class LoginFromTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('Can not resolve reCAPTCHA parameter.');
+        $this->expectExceptionMessage('reCapctha is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaCustomer/Test/Integration/LoginFromTest.php
+++ b/ReCaptchaCustomer/Test/Integration/LoginFromTest.php
@@ -166,7 +166,7 @@ class LoginFromTest extends AbstractController
         $this->setConfig(true, 'test_public_key', 'test_private_key');
 
         $this->expectException(InputException::class);
-        $this->expectExceptionMessage('reCapctha is required.');
+        $this->expectExceptionMessage('reCAPTCHA is required.');
 
         $this->checkPostResponse(false);
     }

--- a/ReCaptchaUi/Model/CaptchaResponseResolver.php
+++ b/ReCaptchaUi/Model/CaptchaResponseResolver.php
@@ -22,7 +22,7 @@ class CaptchaResponseResolver implements CaptchaResponseResolverInterface
     {
         $reCaptchaParam = $request->getParam(self::PARAM_RECAPTCHA);
         if (empty($reCaptchaParam)) {
-            throw new InputException(__('Can not resolve reCAPTCHA parameter.'));
+            throw new InputException(__('reCapctha is required.'));
         }
         return $reCaptchaParam;
     }

--- a/ReCaptchaUi/Model/CaptchaResponseResolver.php
+++ b/ReCaptchaUi/Model/CaptchaResponseResolver.php
@@ -22,7 +22,7 @@ class CaptchaResponseResolver implements CaptchaResponseResolverInterface
     {
         $reCaptchaParam = $request->getParam(self::PARAM_RECAPTCHA);
         if (empty($reCaptchaParam)) {
-            throw new InputException(__('reCapctha is required.'));
+            throw new InputException(__('reCAPTCHA is required.'));
         }
         return $reCaptchaParam;
     }

--- a/ReCaptchaUser/Test/Integration/ForgotPasswordFormTest.php
+++ b/ReCaptchaUser/Test/Integration/ForgotPasswordFormTest.php
@@ -142,7 +142,7 @@ class ForgotPasswordFormTest extends AbstractController
      * @magentoAdminConfigFixture recaptcha_backend/type_invisible/private_key test_private_key
      * @magentoAdminConfigFixture recaptcha_backend/type_for/user_forgot_password invisible
      * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage reCapctha is required.
+     * @expectedExceptionMessage reCAPTCHA is required.
      */
     public function testPostRequestIfReCaptchaParameterIsMissed()
     {

--- a/ReCaptchaUser/Test/Integration/ForgotPasswordFormTest.php
+++ b/ReCaptchaUser/Test/Integration/ForgotPasswordFormTest.php
@@ -142,7 +142,7 @@ class ForgotPasswordFormTest extends AbstractController
      * @magentoAdminConfigFixture recaptcha_backend/type_invisible/private_key test_private_key
      * @magentoAdminConfigFixture recaptcha_backend/type_for/user_forgot_password invisible
      * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage Can not resolve reCAPTCHA parameter.
+     * @expectedExceptionMessage reCapctha is required.
      */
     public function testPostRequestIfReCaptchaParameterIsMissed()
     {

--- a/ReCaptchaUser/Test/Integration/LoginFormTest.php
+++ b/ReCaptchaUser/Test/Integration/LoginFormTest.php
@@ -169,7 +169,7 @@ class LoginFormTest extends AbstractController
         // Location header is different than in the successful case
         $this->assertRedirect(self::equalTo($this->backendUrl->getUrl('admin')));
         $this->assertSessionMessages(
-            self::equalTo(['reCapctha is required.']),
+            self::equalTo(['reCAPTCHA is required.']),
             MessageInterface::TYPE_ERROR
         );
         self::assertFalse($this->auth->isLoggedIn());

--- a/ReCaptchaUser/Test/Integration/LoginFormTest.php
+++ b/ReCaptchaUser/Test/Integration/LoginFormTest.php
@@ -169,7 +169,7 @@ class LoginFormTest extends AbstractController
         // Location header is different than in the successful case
         $this->assertRedirect(self::equalTo($this->backendUrl->getUrl('admin')));
         $this->assertSessionMessages(
-            self::equalTo(['Can not resolve reCAPTCHA parameter.']),
+            self::equalTo(['reCapctha is required.']),
             MessageInterface::TYPE_ERROR
         );
         self::assertFalse($this->auth->isLoggedIn());


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Re-named error message in Resolver to - reCapctha is required.
Also corrected Integration Tests.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/security-package#170: Need to improve error message for Admin Panel if user did not check reCaptcha

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
