### PR TITLE
magento/security-package#224: Recaptcha badge is not shown on checkout login form if 'Invisible Badge Position' is 'Bottom Left/Right' V1

### DIFF
--- a/ReCaptchaCheckout/view/frontend/layout/checkout_index_index.xml
+++ b/ReCaptchaCheckout/view/frontend/layout/checkout_index_index.xml
@@ -9,6 +9,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 
     <body>
+        <referenceBlock name="authentication-popup" remove="true"/>
         <referenceBlock name="checkout.root">
             <arguments>
                 <argument name="jsLayout" xsi:type="array">

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -117,6 +117,11 @@ define(
                     this.settings.rendering
                 );
 
+                // Force inline mode for reCaptcha instances in modal blocks
+                if ($reCaptcha.closest( "[data-role='modal']" ).length > 0) {
+                    parameters.badge = 'inline';
+                }
+
                 // eslint-disable-next-line no-undef
                 widgetId = grecaptcha.render(this.getReCaptchaId(), parameters);
                 this.initParentForm($parentForm, widgetId);

--- a/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion2Invisible/etc/adminhtml/system.xml
@@ -21,6 +21,7 @@
                        showInStore="0" canRestore="1">
                     <label>Invisible Badge Position</label>
                     <source_model>Magento\ReCaptchaVersion2Invisible\Model\OptionSource\Position</source_model>
+                    <comment>Modal blocks ignore this value and render reCaptcha only in the 'inline' position.</comment>
                 </field>
 
                 <field id="theme" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0"

--- a/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
+++ b/ReCaptchaVersion3Invisible/etc/adminhtml/system.xml
@@ -31,6 +31,7 @@
                        showInStore="0" canRestore="1">
                     <label>Invisible Badge Position</label>
                     <source_model>Magento\ReCaptchaVersion3Invisible\Model\OptionSource\Position</source_model>
+                    <comment>Modal blocks ignore this value and render reCaptcha only in the 'inline' position.</comment>
                 </field>
 
                 <field id="theme" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/security-package#224: Recaptcha badge is not shown on checkout login form if 'Invisible Badge Position' is 'Bottom Left/Right'

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/security-package#224

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
