### PR TITLE
magento/security-package#224: Recaptcha badge is not shown on checkout login form if 'Invisible Badge Position' is 'Bottom Left/Right' V2

### DIFF
--- a/ReCaptchaFrontendUi/view/frontend/web/js/nonInlineReCaptchaRenderer.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/nonInlineReCaptchaRenderer.js
@@ -14,29 +14,39 @@ define([
         rendererReCaptcha = null;
 
     return {
+        /**
+         * Add reCaptcha entity to checklist.
+         *
+         * @param {jQuery} reCaptchaEntity
+         * @param {Object} parameters
+         */
         add: function (reCaptchaEntity, parameters) {
-            if (parameters.size === 'invisible' && parameters.badge !== 'inline') {
-                if (!initialized) {
-                    this._init();
-                    grecaptcha.render(rendererRecaptchaId, parameters);
-                    setInterval(this._resolveVisibility, 100);
-                    initialized = true;
-                }
-
-                reCaptchaEntities.push(reCaptchaEntity);
+            if (!initialized) {
+                this.init();
+                grecaptcha.render(rendererRecaptchaId, parameters);
+                setInterval(this.resolveVisibility, 100);
+                initialized = true;
             }
+
+            reCaptchaEntities.push(reCaptchaEntity);
         },
 
-        _resolveVisibility: function () {
+        /**
+         * Show additional reCaptcha instance if any other should be visible, otherwise hide it.
+         */
+        resolveVisibility: function () {
             reCaptchaEntities.some(
                 (entity) => {
                     return entity.is(":visible")
                         // 900 is some magic z-index value of modal popups.
-                        && (entity.closest("[data-role='modal']").length == 0 || entity.zIndex() > 900)
+                        && (entity.closest("[data-role='modal']").length === 0 || entity.zIndex() > 900)
                 }) ? rendererReCaptcha.show() : rendererReCaptcha.hide();
         },
 
-        _init: function () {
+        /**
+         * Initialize additional reCaptcha instance.
+         */
+        init: function () {
             rendererReCaptcha = $('<div/>', {
                 'id': rendererRecaptchaId
             });

--- a/ReCaptchaFrontendUi/view/frontend/web/js/nonInlineReCaptchaRenderer.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/nonInlineReCaptchaRenderer.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery'
+], function ($) {
+    'use strict';
+
+    var reCaptchaEntities = [],
+        initialized = false,
+        rendererRecaptchaId = 'recaptcha-invisible',
+        rendererReCaptcha = null;
+
+    return {
+        add: function (reCaptchaEntity, parameters) {
+            if (parameters.size === 'invisible' && parameters.badge !== 'inline') {
+                if (!initialized) {
+                    this._init();
+                    grecaptcha.render(rendererRecaptchaId, parameters);
+                    setInterval(this._resolveVisibility, 100);
+                    initialized = true;
+                }
+
+                reCaptchaEntities.push(reCaptchaEntity);
+            }
+        },
+
+        _resolveVisibility: function () {
+            reCaptchaEntities.some(
+                (entity) => {
+                    return entity.is(":visible")
+                        // 900 is some magic z-index value of modal popups.
+                        && (entity.closest("[data-role='modal']").length == 0 || entity.zIndex() > 900)
+                }) ? rendererReCaptcha.show() : rendererReCaptcha.hide();
+        },
+
+        _init: function () {
+            rendererReCaptcha = $('<div/>', {
+                'id': rendererRecaptchaId
+            });
+            $('body').append(rendererReCaptcha);
+        }
+    };
+});

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -11,9 +11,10 @@ define(
         'jquery',
         'ko',
         'Magento_ReCaptchaFrontendUi/js/registry',
-        'Magento_ReCaptchaFrontendUi/js/reCaptchaScriptLoader'
+        'Magento_ReCaptchaFrontendUi/js/reCaptchaScriptLoader',
+        'Magento_ReCaptchaFrontendUi/js/nonInlineReCaptchaRenderer',
     ],
-    function (Component, $, ko, registry, reCaptchaLoader, undefined) {
+    function (Component, $, ko, registry, reCaptchaLoader,nonInlineReCaptchaRenderer, undefined) {
         'use strict';
 
         return Component.extend({
@@ -116,6 +117,8 @@ define(
                     },
                     this.settings.rendering
                 );
+
+                nonInlineReCaptchaRenderer.add($reCaptcha, parameters);
 
                 // eslint-disable-next-line no-undef
                 widgetId = grecaptcha.render(this.getReCaptchaId(), parameters);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/security-package#224: Recaptcha badge is not shown on checkout login form if 'Invisible Badge Position' is 'Bottom Left/Right'

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/security-package#224

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
