### PR TITLE
magento/security-package#242: ReCAPTCHA v2 ("I am not a robot") for Newsletter Subscription displays with error.

### DIFF
--- a/ReCaptchaNewsletter/etc/adminhtml/system.xml
+++ b/ReCaptchaNewsletter/etc/adminhtml/system.xml
@@ -13,8 +13,10 @@
                 <field id="newsletter" translate="label comment" type="select" sortOrder="160" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable Invisible reCAPTCHA in Newsletter Subscription</label>
-                    <comment>If enabled, a badge will be displayed in every page.</comment>
+                    <comment><![CDATA[If enabled, a badge will be displayed in every page.
+                    </br>Only Invisible reCaptcha types may be selected.]]></comment>
                     <source_model>Magento\ReCaptchaAdminUi\Model\OptionSource\Type</source_model>
+                    <frontend_model>Magento\ReCaptchaUi\Model\OptionSource\InvisibleOnlyField</frontend_model>
                 </field>
             </group>
         </section>

--- a/ReCaptchaUi/Model/OptionSource/InvisibleOnlyField.php
+++ b/ReCaptchaUi/Model/OptionSource/InvisibleOnlyField.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ReCaptchaUi\Model\OptionSource;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\ReCaptchaUi\Model\UiConfigResolver;
+
+/**
+ * Display only invisible reCaptcha types.
+ */
+class InvisibleOnlyField extends Field
+{
+    /**
+     * @var UiConfigResolver
+     */
+    private $uiConfigResolver;
+
+    /**
+     * @param Context $context
+     * @param UiConfigResolver $uiConfigResolver
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        UiConfigResolver $uiConfigResolver,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->uiConfigResolver = $uiConfigResolver;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render(AbstractElement $element)
+    {
+        $result = $values = $element->getData('values');
+        foreach ($values as $key => $data) {
+            if (isset($data['value']) && $data['value'] !== null) {
+                $config = $this->uiConfigResolver->getByName($data['value']);
+                if (!isset($config['invisible']) || !$config['invisible']) {
+                    unset($result[$key]);
+                }
+            }
+        }
+        $element->setData('values', $result);
+
+        return parent::render($element);
+    }
+}

--- a/ReCaptchaUi/Model/UiConfigResolver.php
+++ b/ReCaptchaUi/Model/UiConfigResolver.php
@@ -62,4 +62,22 @@ class UiConfigResolver implements UiConfigResolverInterface
         }
         return $this->uiConfigProviders[$captchaType]->get();
     }
+
+    /**
+     * Get UiConfigProvider data by given UiConfigProvider name.
+     *
+     * @param string $name
+     * @return array
+     * @throws InputException
+     */
+    public function getByName(string $name): array
+    {
+        if (!isset($this->uiConfigProviders[$name])) {
+            throw new InputException(
+                __('UI config provider for "%type" is not configured.', ['type' => $name])
+            );
+        }
+
+        return $this->uiConfigProviders[$name]->get();
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/security-package#242: ReCAPTCHA v2 ("I am not a robot") for Newsletter Subscription displays with error.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/security-package#242: ReCAPTCHA v2 ("I am not a robot") for Newsletter Subscription displays with error.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
