### PR TITLE
Fixed invalid html link logout in 2fa screen auth

### DIFF
--- a/TwoFactorAuth/view/adminhtml/layout/tfa_screen.xml
+++ b/TwoFactorAuth/view/adminhtml/layout/tfa_screen.xml
@@ -7,19 +7,19 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-
     <head>
         <css src="Magento_TwoFactorAuth::css/tfa-screen.css"/>
     </head>
-
     <body>
         <referenceContainer name="login.content">
-            <block class="Magento\Framework\View\Element\Html\Link" name="logout.link">
-                <arguments>
-                    <argument name="label" xsi:type="string"  translate="false">Logout</argument>
-                    <argument name="path" xsi:type="string" translate="false">adminhtml/auth/logout</argument>
-                    <argument name="class" xsi:type="string" translate="false">tfa-logout-link</argument>
-                </arguments>
+            <block class="Magento\Framework\View\Element\Html\Links" name="2fa.links">
+                <block class="Magento\Framework\View\Element\Html\Link" name="logout.link">
+                    <arguments>
+                        <argument name="label" xsi:type="string"  translate="false">Logout</argument>
+                        <argument name="path" xsi:type="string" translate="false">adminhtml/auth/logout</argument>
+                        <argument name="class" xsi:type="string" translate="false">tfa-logout-link</argument>
+                    </arguments>
+                </block>
             </block>
         </referenceContainer>
     </body>

--- a/TwoFactorAuth/view/adminhtml/web/css/tfa-screen.css
+++ b/TwoFactorAuth/view/adminhtml/web/css/tfa-screen.css
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-.login-content > li {
+.login-content > ul {
     list-style: none;
 }
 .tfa-logout-link {
@@ -11,3 +11,4 @@
     top: 1em;
     right: 1em;
 }
+


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Previous html render li without ul wrapper outside
=> Not valid html standards

Before this patch markup

div > li (Miss ul)

After this patch markup

div > ul > li

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
