### PR TITLE
Fix for issue #285

### DIFF
--- a/TwoFactorAuth/Model/Config/UserNotifier.php
+++ b/TwoFactorAuth/Model/Config/UserNotifier.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\TwoFactorAuth\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\UrlInterface;
+use Magento\Backend\Model\UrlInterface;
 
 /**
  * Represents configuration for notifying the user


### PR DESCRIPTION
### Description (*)
Email notification for 2FA configuration has a wrong link, which leads to 404 page

### Fixed Issues (if relevant)
1. magento/security-package#285: Email notification for 2FA configuration has a wrong link, which leads to 404 page

### Manual testing scenarios (*)
1. Login to admin panel
2. Go to System - Permissions - All Users
3. Add a new admin user
4. Send a /rest/default/V1/integration/admin/token POST request with username and password  from step 3
You will get a response about email notification has been sent
![image](https://user-images.githubusercontent.com/1975805/104316222-6f31b900-54dc-11eb-8f7d-38b3c165b425.png)
5. Check received email and click the link
![image](https://user-images.githubusercontent.com/1975805/104316476-cd5e9c00-54dc-11eb-8ebe-eba1ad10a679.png) 
![image](https://user-images.githubusercontent.com/1975805/104316467-c9327e80-54dc-11eb-90ac-9d32e03d539a.png)
6. Link should lead to the 2FA settings page


### Contribution checklist (*)
 - [x] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
