### PR TITLE
Removing the unused `phpseclib/phpseclib` composer package in TwoFactorAuth

### DIFF
--- a/TwoFactorAuth/composer.json
+++ b/TwoFactorAuth/composer.json
@@ -16,8 +16,7 @@
         "spomky-labs/otphp": "^10.0",
         "endroid/qr-code": "^3.7",
         "donatj/phpuseragentparser": "~0.7",
-        "2tvenom/cborencode": "^1.0",
-        "phpseclib/phpseclib": "2.0.*"
+        "2tvenom/cborencode": "^1.0"
     },
     "type": "magento2-module",
     "license": "OSL-3.0",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Description (*)
This PR aims to remove the unused `phpseclib/phpseclib` composer package.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
