### PR TITLE
Fix typo

### DIFF
--- a/TwoFactorAuth/Controller/Adminhtml/Tfa/Configurepost.php
+++ b/TwoFactorAuth/Controller/Adminhtml/Tfa/Configurepost.php
@@ -124,7 +124,7 @@ class Configurepost extends AbstractAction implements HttpPostActionInterface
             );
             $this->config->reinit();
             $this->getMessageManager()->addSuccessMessage(
-                __('Two-Factory Authorization providers have been successfully configured')
+                __('Two-Factor Authorization providers have been successfully configured')
             );
 
             return $this->_redirect($this->startUpUrl);


### PR DESCRIPTION
Simple typo fix: `Two-Factory Authorization` -> `Two-Factor Authorization`.

The bug in action:
![screenshot of bug](https://user-images.githubusercontent.com/615684/208202044-e4cf00a6-6f19-4e62-b419-80e90eb272a8.png)

### Contribution checklist (*)

 - [x] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] ~All new or changed code is covered with unit/integration tests (if applicable)~ (N/A - text change)
 - [ ] All automated tests passed successfully (all builds are green)