### PR TITLE
Load recaptcha related files on focus of the form fields.

### DIFF
--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -33,8 +33,7 @@ define(
             },
 
             attachFocusEvent: function () {
-                const $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
-                const self = this;
+                const self = this, $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
 
                 $parentForm.find('input, select').on('focus', function () {
                     self._loadApi();

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -33,7 +33,7 @@ define(
             },
 
             attachFocusEvent: function () {
-                let parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
+                const $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
                 let self = this;
 
                 parentForm.find('input, select').on('focus', function () {

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -36,7 +36,7 @@ define(
                 const $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
                 const self = this;
 
-                parentForm.find('input, select').on('focus', function () {
+                $parentForm.find('input, select').on('focus', function () {
                     self._loadApi();
                 });
             },

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -34,7 +34,7 @@ define(
 
             attachFocusEvent: function () {
                 const $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
-                let self = this;
+                const self = this;
 
                 parentForm.find('input, select').on('focus', function () {
                     self._loadApi();

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -28,7 +28,17 @@ define(
              */
             initialize: function () {
                 this._super();
-                this._loadApi();
+
+                this.attachFocusEvent();
+            },
+
+            attachFocusEvent: function () {
+                let parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
+                let self = this;
+
+                parentForm.find('input, select').on('focus', function () {
+                    self._loadApi();
+                });
             },
 
             /**
@@ -59,9 +69,7 @@ define(
              * @returns {Boolean}
              */
             getIsInvisibleRecaptcha: function () {
-                if (this.settings ===
-
-                    void 0) {
+                if (this.settings === void 0) {
                     return false;
                 }
 
@@ -95,9 +103,7 @@ define(
                     widgetId,
                     parameters;
 
-                if (this.captchaInitialized || this.settings ===
-
-                    void 0) {
+                if (this.captchaInitialized || this.settings === void 0) {
                     return;
                 }
 

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -35,7 +35,7 @@ define(
             attachFocusEvent: function () {
                 const self = this, $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
 
-                $parentForm.find('input, select').on('focus', function () {
+                $parentForm.one('focus', 'input, select, textarea', function () {
                     self._loadApi();
                 });
             },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
reCaptcha remote files will be loaded only if customer (visitor) focus on the fields for the form for which reCaptcha is enabled. This will reduce loaded files and immediately reflects to loading time.

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/security-package/issues/333
2. Fixes https://github.com/magento/magento2/issues/38303

### Manual testing scenarios (*)
1. Enable reCaptcha (no matter which version) for Newsletter, Contact Form, Review, Registration or ... anything.
2. Load the page which will contains form for which reCaptcha is enabled (Ex. Contact form /contact)
4. ReCaptcha external (gstatic.com) files will not be loaded (you will not see the logo of the recaptcha or loaded files in the network tab of the browser developer inspector).
5. Click on the first or random field (Ex. Name) 
6. Recaptcha files will be loaded and you will see logo of the repCaptcha somewhere on the page as you are configured in the step 1.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
