### PR TITLE
Move permission for Two Factor Auth to top

### DIFF
--- a/TwoFactorAuth/etc/acl.xml
+++ b/TwoFactorAuth/etc/acl.xml
@@ -10,14 +10,10 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Magento_Backend::system">
-                    <resource id="Magento_User::acl">
-                        <resource id="Magento_TwoFactorAuth::tfa"
-                                  title="Two Factor Auth"
-                                  translate="title"
-                                  sortOrder="40" />
-                    </resource>
-                </resource>
+                <resource id="Magento_TwoFactorAuth::tfa"
+                          title="Use Two Factor Auth"
+                          translate="title"
+                          sortOrder="40" />
 
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">


### PR DESCRIPTION
Fix: As a restricted user I want to be able to setup and login using TFA, without seeing an empty System -> Permissions menu

### Description (*)

We have very restricted users who can only see a sales menu; now they should be able to use TFA which needs the `Magento_TwoFactorAuth::tfa` permission. But this would require to also see the system menu

### Fixed Issues (if relevant)


### Manual testing scenarios (*)
1. give only a sales order menu and "Use Two Factor Auth" permission
2. login using TFA, see only the sales menu

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
