### PR TITLE
Fix spacing of i18n label

### DIFF
--- a/TwoFactorAuth/view/adminhtml/web/template/google/configure.html
+++ b/TwoFactorAuth/view/adminhtml/web/template/google/configure.html
@@ -16,7 +16,7 @@
 
                 <p class="tfa-google-secure-code" data-bind='i18n: getSecretCode()'></p>
 
-                <p data-bind='i18n: "Scan or copy&amp;paste this code with your authenticator app and insert your code to confirm."'></p>
+                <p data-bind='i18n: "Scan or copy &amp; paste this code with your authenticator app and insert your code to confirm."'></p>
 
                 <div class="admin__field _required field-tfa_code">
                     <label for="tfa_code" class="admin__field-label">


### PR DESCRIPTION
This PR fixes the spacing of the Two Factor setup page which has been driving me insane since 2020.