### PR TITLE
magento/magento2#39836: Use of --lock-env on bin/magento config:set t…

### DIFF
--- a/TwoFactorAuth/Model/Provider/Engine/DuoSecurity.php
+++ b/TwoFactorAuth/Model/Provider/Engine/DuoSecurity.php
@@ -196,7 +196,11 @@ class DuoSecurity implements EngineInterface
     private function isDuoForcedProvider(): bool
     {
         $providers = $this->scopeConfig->getValue('twofactorauth/general/force_providers') ?? '';
-        $forcedProviders = array_map('trim', explode(',', $providers));
+        if (is_array($providers)) {
+            $forcedProviders = array_map('trim', $providers);
+        } else {
+            $forcedProviders = array_map('trim', explode(',', (string)$providers));
+        }
         return in_array(self::CODE, $forcedProviders, true);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
- Fix TypeError in DuoSecurity when force_providers is array
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#39836: Use of --lock-env on bin/magento config:set twofactorauth/general/force_providers results in bin/magento errors 



### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run bin/magento config:set --lock-env twofactorauth/general/force_providers google.
2. Run bin/magento

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
