### PR TITLE
Fix 2FA admin emails silently suppressed when default store has email disabled

### DIFF
--- a/TwoFactorAuth/Model/EmailUserNotifier.php
+++ b/TwoFactorAuth/Model/EmailUserNotifier.php
@@ -8,7 +8,10 @@ declare(strict_types=1);
 
 namespace Magento\TwoFactorAuth\Model;
 
+use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TwoFactorAuth\Model\Config\UserNotifier as UserNotifierConfig;
 use Magento\User\Model\User;
@@ -48,24 +51,33 @@ class EmailUserNotifier implements UserNotifierInterface
     private $userNotifierConfig;
 
     /**
+     * @var Emulation
+     */
+    private $appEmulation;
+
+    /**
      * @param ScopeConfigInterface $scopeConfig
      * @param TransportBuilder $transportBuilder
      * @param StoreManagerInterface $storeManager
      * @param LoggerInterface $logger
      * @param UserNotifierConfig $userNotifierConfig
+     * @param Emulation|null $appEmulation
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         TransportBuilder $transportBuilder,
         StoreManagerInterface $storeManager,
         LoggerInterface $logger,
-        UserNotifierConfig $userNotifierConfig
+        UserNotifierConfig $userNotifierConfig,
+        ?Emulation $appEmulation = null
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->transportBuilder = $transportBuilder;
         $this->storeManager = $storeManager;
         $this->logger = $logger;
         $this->userNotifierConfig = $userNotifierConfig;
+        $this->appEmulation = $appEmulation
+            ?? \Magento\Framework\App\ObjectManager::getInstance()->get(Emulation::class);
     }
 
     /**
@@ -103,7 +115,16 @@ class EmailUserNotifier implements UserNotifierInterface
                 )
                 ->addTo($user->getEmail(), $user->getFirstName() . ' ' . $user->getLastName())
                 ->getTransport();
-            $transport->sendMessage();
+            // The send-suppression check in TransportInterfacePlugin reads system/smtp/disable from
+            // whatever store the environment currently resolves to, not from the store this email was
+            // rendered for above. Emulate the default/admin store so it checks the same global scope
+            // that this notification is actually governed by, rather than an unrelated frontend store.
+            $this->appEmulation->startEnvironmentEmulation(Store::DEFAULT_STORE_ID, Area::AREA_ADMINHTML);
+            try {
+                $transport->sendMessage();
+            } finally {
+                $this->appEmulation->stopEnvironmentEmulation();
+            }
         } catch (\Throwable $exception) {
             $this->logger->critical($exception);
             throw new NotificationException('Failed to send 2FA E-mail to a user', 0, $exception);

--- a/TwoFactorAuth/Test/Unit/Model/EmailUserNotifierTest.php
+++ b/TwoFactorAuth/Test/Unit/Model/EmailUserNotifierTest.php
@@ -22,6 +22,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class EmailUserNotifierTest extends TestCase
 {
     /**
@@ -78,7 +81,7 @@ class EmailUserNotifierTest extends TestCase
         $this->transportBuilderMock->method('addTo')->willReturnSelf();
         $this->transportBuilderMock->method('getTransport')->willReturn($this->transportMock);
 
-        $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);
+        $storeMock = $this->createMock(Store::class);
         $storeMock->method('getFrontendName')->willReturn('Main Website Store');
         $this->storeManagerMock->method('getStore')->willReturn($storeMock);
 

--- a/TwoFactorAuth/Test/Unit/Model/EmailUserNotifierTest.php
+++ b/TwoFactorAuth/Test/Unit/Model/EmailUserNotifierTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\TwoFactorAuth\Test\Unit\Model;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Mail\TransportInterface;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TwoFactorAuth\Model\Config\UserNotifier as UserNotifierConfig;
+use Magento\TwoFactorAuth\Model\EmailUserNotifier;
+use Magento\User\Model\User;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class EmailUserNotifierTest extends TestCase
+{
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $scopeConfigMock;
+
+    /**
+     * @var TransportBuilder|MockObject
+     */
+    private $transportBuilderMock;
+
+    /**
+     * @var StoreManagerInterface|MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var UserNotifierConfig|MockObject
+     */
+    private $userNotifierConfigMock;
+
+    /**
+     * @var Emulation|MockObject
+     */
+    private $appEmulationMock;
+
+    /**
+     * @var TransportInterface|MockObject
+     */
+    private $transportMock;
+
+    /**
+     * @var EmailUserNotifier
+     */
+    private $notifier;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $this->transportBuilderMock = $this->createMock(TransportBuilder::class);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->userNotifierConfigMock = $this->createMock(UserNotifierConfig::class);
+        $this->appEmulationMock = $this->createMock(Emulation::class);
+        $this->transportMock = $this->createMock(TransportInterface::class);
+
+        $this->transportBuilderMock->method('setTemplateIdentifier')->willReturnSelf();
+        $this->transportBuilderMock->method('setTemplateOptions')->willReturnSelf();
+        $this->transportBuilderMock->method('setTemplateVars')->willReturnSelf();
+        $this->transportBuilderMock->method('setFromByScope')->willReturnSelf();
+        $this->transportBuilderMock->method('addTo')->willReturnSelf();
+        $this->transportBuilderMock->method('getTransport')->willReturn($this->transportMock);
+
+        $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);
+        $storeMock->method('getFrontendName')->willReturn('Main Website Store');
+        $this->storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $this->notifier = new EmailUserNotifier(
+            $this->scopeConfigMock,
+            $this->transportBuilderMock,
+            $this->storeManagerMock,
+            $this->createMock(LoggerInterface::class),
+            $this->userNotifierConfigMock,
+            $this->appEmulationMock
+        );
+    }
+
+    /**
+     * The email is built for store 0/adminhtml, but the send-suppression plugin reads
+     * system/smtp/disable from whatever store the environment currently resolves to. The send call
+     * must happen inside default-store/adminhtml emulation so that check is scoped correctly too.
+     */
+    public function testSendMessageIsEmulatedAsDefaultStoreAdminhtml(): void
+    {
+        $callOrder = [];
+        $this->appEmulationMock->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with(Store::DEFAULT_STORE_ID, Area::AREA_ADMINHTML)
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'start';
+            });
+        $this->transportMock->expects($this->once())
+            ->method('sendMessage')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'send';
+            });
+        $this->appEmulationMock->expects($this->once())
+            ->method('stopEnvironmentEmulation')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'stop';
+            });
+
+        $user = $this->createMock(User::class);
+        $user->method('getEmail')->willReturn('admin@example.com');
+        $user->method('getFirstName')->willReturn('Jane');
+        $user->method('getLastName')->willReturn('Doe');
+
+        $this->userNotifierConfigMock->method('getPersonalRequestConfigUrl')->willReturn('http://example.com/token');
+
+        $this->notifier->sendUserConfigRequestMessage($user, 'token');
+
+        self::assertSame(['start', 'send', 'stop'], $callOrder);
+    }
+
+    /**
+     * Emulation must be torn down even if sending itself throws, otherwise the admin store context
+     * leaks into the rest of the request.
+     */
+    public function testEmulationIsStoppedEvenWhenSendMessageThrows(): void
+    {
+        $this->appEmulationMock->expects($this->once())->method('startEnvironmentEmulation');
+        $this->transportMock->method('sendMessage')->willThrowException(new \RuntimeException('SMTP down'));
+        $this->appEmulationMock->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $user = $this->createMock(User::class);
+        $user->method('getEmail')->willReturn('admin@example.com');
+        $user->method('getFirstName')->willReturn('Jane');
+        $user->method('getLastName')->willReturn('Doe');
+
+        $this->userNotifierConfigMock->method('getAppRequestConfigUrl')->willReturn('http://example.com/token');
+
+        $this->expectException(\Magento\TwoFactorAuth\Model\Exception\NotificationException::class);
+        $this->notifier->sendAppConfigRequestMessage($user, 'token');
+    }
+}


### PR DESCRIPTION
### Description

`EmailUserNotifier::sendConfigRequired()` renders its 2FA-instructions email for `'area' => 'adminhtml', 'store' => 0`, but that option only affects the template's locale/content. Whether the email actually gets sent is decided by a completely separate, global plugin in Magento core: `Magento\Email\Model\Mail\TransportInterfacePlugin::aroundSendMessage()`, which checks:

```php
$this->scopeConfig->isSetFlag('system/smtp/disable', ScopeInterface::SCOPE_STORE)
```

with no explicit scope code. That resolves against whatever store `StoreManagerInterface::getStore()` considers "current" at that moment — in a live adminhtml request (no frontend store context), Magento's store resolution falls through to the default store of the default website, not store 0. If that store specifically has email communication disabled, every 2FA notification is silently swallowed, even though this email is architecturally meant to be governed by the global/default scope.

This mirrors a very similar, already-fixed bug in `Magento\ProductAlert\Model\Email::send()` (ticket ACP2E-4870, "Product Alert Consumer ignores store scoped system/smtp/disable"), which wraps its own `sendMessage()` call in `App\Emulation::startEnvironmentEmulation()`/`stopEnvironmentEmulation()` so the ambient store the suppression check reads actually matches the store the email was built for.

This PR applies the same pattern here, emulating `Store::DEFAULT_STORE_ID` / `Area::AREA_ADMINHTML` around the `sendMessage()` call, so the plugin's scope-less check resolves to the same global scope this notification is rendered for, instead of an unrelated frontend store. The `TransportInterfacePlugin` itself is intentionally left untouched — it's a shared plugin wrapping every outgoing email in Magento, and changing its scope resolution would break legitimate per-store suppression for genuinely store-scoped emails (newsletters, product alerts, etc., including the ACP2E-4870 fix it relies on).

### Related Issue

Fixes https://github.com/magento/magento2/issues/40969

### Manual testing scenarios

1. Set `system/smtp/disable` (Store Email Addresses config or direct `core_config_data` row) to `1` for a specific store, e.g. the default store of the default website.
2. Enable 2FA and create/edit an admin user so a "configuration required" 2FA email would normally be triggered.
3. Before this fix: the email is silently not sent, no error surfaced. After this fix: the email sends normally, since the suppression check now correctly reads the default/global scope rather than the disabled store's scope.

### Questions or comments

None.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility